### PR TITLE
ci: github action test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,11 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
+    - uses: actions/setup-node@v2
       with:
-        path: '**/node_modules'
-        key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.lock') }}
+        node-version: '16'
+        cache: 'npm'
     - name: Install modules
-      run: npm install
+      run: npm ci
     - name: Run Jest tests
       run: npm t


### PR DESCRIPTION
This fixes a few issues with the test action

* The default version of node is 14 which doesn't have access to the crypto api
* Setup-node action also simplifies the caching of npm modules
* `npm install` doesn't guarantee the same package versions, switching to `npm ci` to keep versions the same as lock file.